### PR TITLE
path to nvcc automatically determined

### DIFF
--- a/dd_1d_global/Makefile
+++ b/dd_1d_global/Makefile
@@ -1,4 +1,4 @@
-NVCC = /usr/local/cuda/bin/nvcc
+NVCC = $(shell which nvcc)
 NVCC_FLAGS = -g -G -Xcompiler -Wall
 
 all: main.exe

--- a/dd_1d_shared/Makefile
+++ b/dd_1d_shared/Makefile
@@ -1,4 +1,4 @@
-NVCC = /usr/local/cuda/bin/nvcc
+NVCC = $(shell which nvcc)
 NVCC_FLAGS = -g -G -Xcompiler -Wall
 
 all: main.exe


### PR DESCRIPTION
These small modifications in the makefiles allow to automatically locate the nvcc compiler in linux machines