### PR TITLE
Added code in Listing 4.3 from book; comment about possible bug in dd_1d_shared

### DIFF
--- a/dd_1d_shared/kernel.cu
+++ b/dd_1d_shared/kernel.cu
@@ -15,6 +15,8 @@ void ddKernel(float *d_out, const float *d_in, int size, float h) {
 
   // Halo cells
   if (threadIdx.x < RAD) {
+    // careful: the two lines below will also access d_in[-1] and d_in[size+1] which 
+    // are undefined! This bug is fixed in heat_2d (cf. idxClip function)
     s_in[s_idx - RAD] = d_in[i - RAD];
     s_in[s_idx + blockDim.x] = d_in[i + blockDim.x];
   }

--- a/dist_2d/Makefile
+++ b/dist_2d/Makefile
@@ -1,0 +1,10 @@
+NVCC = /usr/local/cuda/bin/nvcc
+NVCC_FLAGS = -g -G -Xcompiler -Wall
+
+all: main.exe
+
+main.exe: main.cu
+	$(NVCC) $^ -o $@
+
+clean:
+	rm -f *.o *.exe

--- a/dist_2d/main.cu
+++ b/dist_2d/main.cu
@@ -1,0 +1,39 @@
+#define W 500
+#define H 500
+#define TX 32 // number of threads per block along x-axis
+#define TY 32 // number of threads per block along y-axis
+
+__global__ void distanceKernel(float *d_out, int w, int h, float2 pos) 
+{
+  const int c = blockIdx.x*blockDim.x + threadIdx.x;
+  const int r = blockIdx.y*blockDim.y + threadIdx.y;
+  const int i=r*w+c;
+
+  if ((c >= w) || (r >= h)) return; 
+
+  // Compute the distance and set d_out[i]
+  d_out[i] = sqrtf((c - pos.x)*(c - pos.x) + (r - pos.y)*(r - pos.y));
+}
+
+int main() 
+{
+  float *out = (float*)calloc(W*H, sizeof(float));
+  float *d_out; // pointer for device array
+
+  cudaMalloc(&d_out,W*H*sizeof(float));
+
+  const float2 pos = {0.0f, 0.0f}; // set reference position
+  const dim3 blockSize(TX, TY);
+  const int bx=(W+TX-1)/TX;
+  const int by=(W+TY-1)/TY;
+  const dim3 gridSize = dim3(bx,by);
+
+  distanceKernel<<<gridSize, blockSize>>>(d_out, W, H, pos);
+
+  // Copy results to host.
+  cudaMemcpy(out, d_out, W*H*sizeof(float), cudaMemcpyDeviceToHost);
+
+  cudaFree(d_out);
+  free(out);
+  return 0;
+}


### PR DESCRIPTION
I copied the code from Listing 4.3 in the book into folder `dist_2d` for completeness. 

I also found a potential bug in `dd_1d_shared`. Namely, when defining the shared array, it accesses elements -1 and size+1 which are undefined and could lead to potential errors. This was fixed in the `heat_2d` shared array code by means of `idxClip` function which makes sure the code only reads within the boundaries of the array.